### PR TITLE
[add] parse command parameters using stringstream and validation check

### DIFF
--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -1,7 +1,28 @@
 #include "CommandParser.h"
+#include <sstream>
+using namespace std;
 
 int CommandParser::runCommand(const string cmd) {
-	return getCommandType(cmd);
+	// Precondition
+	vector<string> cmdParms = getCommandParams(cmd);
+	if (invalidCommandCheck(cmdParms[0]) == false)
+		return CMD_NOT_SUPPORTED;
+	if (checkParamNum(cmdParms) == false)
+		return CMD_NOT_SUPPORTED;
+	// TODO : Run command and Print Log
+	return getCommandType(cmdParms[0]);
+}
+
+vector<string> CommandParser::getCommandParams(const string& cmd)
+{
+	stringstream stream(cmd);
+	string word;
+	vector<string> tokens;
+
+	while (stream >> word) {
+		tokens.push_back(word);
+	}
+	return tokens;
 }
 
 int CommandParser::getCommandType(const string cmd)

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -36,6 +36,7 @@ public:
 		{"fullread",0,false,false} };
 
 	int runCommand(const string cmd);
+	vector<string> getCommandParams(const std::string& cmd);
 	int getCommandType(const string cmd);
 	bool invalidCommandCheck(string str);
 	bool checkParamNum(vector<string> str);

--- a/TestShell_Excutor/CommandParser_test.cpp
+++ b/TestShell_Excutor/CommandParser_test.cpp
@@ -29,3 +29,14 @@ TEST(CPTest, RunCommandCallExit) {
 	const string cmdline = "exit";
 	EXPECT_EQ(CMD_BASIC_EXIT, cp.runCommand(cmdline));
 }
+
+TEST(CPTest, RunCommandCallWrite) {
+	CommandParser cp;
+	const string cmdline = "write 3 0xAAAABBBB";
+	EXPECT_EQ(CMD_BASIC_WRITE, cp.runCommand(cmdline));
+}
+TEST(CPTest, RunCommandCallRed) {
+	CommandParser cp;
+	const string cmdline = "read 0";
+	EXPECT_EQ(CMD_BASIC_READ, cp.runCommand(cmdline));
+}


### PR DESCRIPTION
This patch parses command parameters using stringstream and validation check by invalidCommandCheck/checkParamNum