### PR TITLE
[fix] remove redundant semicolon to discard build warnings

### DIFF
--- a/TestShell_Excutor/main.cpp
+++ b/TestShell_Excutor/main.cpp
@@ -1,5 +1,5 @@
 #include "gmock/gmock.h"
-#include "CommandParser.h";
+#include "CommandParser.h"
 using std::string;
 using std::cout;
 


### PR DESCRIPTION
What:
빌드 워닝 유발하는 불필요한 세미콜론 제거 하였습니다.