### PR TITLE
[add] Invalid value check

### DIFF
--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -70,7 +70,7 @@ bool CommandParser::checkValidLBA(vector<string> cmdSplits)
 			{
 
 				string lbastr = cmdSplits[1];
-				if (lbastr.size() > 2)
+				if (lbastr.size() <= 0 || lbastr.size() > LBAMAXLENGTH)
 					return false;
 				
 				for (char lbach : lbastr)
@@ -98,12 +98,12 @@ bool CommandParser::checkValidValue(vector<string> cmdSplits)
 			{
 				int valueIndex = cmddata.paramnum-1; //value is lastindex
 				string valueStr = cmdSplits[valueIndex];
-				if (valueStr.size() != 10)
+				if (valueStr.size() != VALUELENGTH)
 					return false;
 				else if (valueStr[0] != '0' || valueStr[1] != 'x')
 					return false;
 				bool result = true;
-				for (int i = 2; i < 10; i++)
+				for (int i = VALUESTART; i < VALUELENGTH; i++)
 				{
 					if (valueStr[i] >= '0' && valueStr[i] <= '9')
 						continue;
@@ -115,7 +115,7 @@ bool CommandParser::checkValidValue(vector<string> cmdSplits)
 				return true;
 			}
 			else
-				return true;
+				return true; //not use value string
 		}
 	}
 	return false;

--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -88,5 +88,38 @@ bool CommandParser::checkValidLBA(vector<string> cmdSplits)
 	return false;
 }
 
+bool CommandParser::checkValidValue(vector<string> cmdSplits)
+{
+	for (CommandFormat cmddata : commandlist)
+	{
+		if (cmddata.cmd == cmdSplits[0])
+		{
+			if (cmddata.isUseValue)
+			{
+				int valueIndex = cmddata.paramnum-1; //value is lastindex
+				string valueStr = cmdSplits[valueIndex];
+				if (valueStr.size() != 10)
+					return false;
+				else if (valueStr[0] != '0' || valueStr[1] != 'x')
+					return false;
+				bool result = true;
+				for (int i = 2; i < 10; i++)
+				{
+					if (valueStr[i] >= '0' && valueStr[i] <= '9')
+						continue;
+					else if (valueStr[i] >= 'A' && valueStr[i] <= 'F')
+						continue;
+					else
+						return false;
+				}	
+				return true;
+			}
+			else
+				return true;
+		}
+	}
+	return false;
+}
+
 
 

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -43,6 +43,10 @@ public:
 	bool checkValidLBA(vector<string> str);
 	bool checkValidValue(vector<string> str);
 private:
+	const int LBAMAXLENGTH = 2;
+	const int VALUESTART = 2;
+	const int VALUELENGTH = 10;
+
 	std::unordered_map<string, int> cmdMap = {
 		{"write", CMD_BASIC_WRITE },
 		{"read", CMD_BASIC_READ },

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -41,7 +41,7 @@ public:
 	bool invalidCommandCheck(string str);
 	bool checkParamNum(vector<string> str);
 	bool checkValidLBA(vector<string> str);
-
+	bool checkValidValue(vector<string> str);
 private:
 	std::unordered_map<string, int> cmdMap = {
 		{"write", CMD_BASIC_WRITE },

--- a/TestShell_Excutor/InvalidCmd_test.cpp
+++ b/TestShell_Excutor/InvalidCmd_test.cpp
@@ -154,14 +154,21 @@ TEST(INVALIDCMD, CHECKVALUE_FAIL)
 		{ "write","93","0x12345678AAA" },
 		{ "write","93","qwertyuiop" },
 		{ "write","93","01234567x0" },
+		{ "write","93","0x1234abcd" },		
+		{ "fullwrite","0x1234" },
+		{ "fullwrite","0x12345678AAA" },
+		{ "fullwrite","qwertyuiop" },
+		{ "fullwrite","01234567x0" },
+		{ "fullwrite","0x1234abcd" },	
+
 	};
-	bool returnval = true;
+	int passIndex = 0;
 	for (vector<string> cmd : invalidcmdlist)
 	{
-		returnval = parser.checkValidLBA(cmd);
-		if (returnval == true)
+		if (parser.checkValidValue(cmd) == true)
 			break;
+		passIndex++;
 	}
 	
-	EXPECT_EQ(false, returnval);
+	EXPECT_EQ(10, passIndex);
 }

--- a/TestShell_Excutor/InvalidCmd_test.cpp
+++ b/TestShell_Excutor/InvalidCmd_test.cpp
@@ -127,7 +127,7 @@ TEST(INVALIDCMD, CHECKLBA_NOTNUMBER)
 	bool returnval = parser.checkValidLBA(wrcmd);
 	EXPECT_EQ(false, returnval);
 }
-TEST(INVALIDCMD, CHECKWRITELBA_FAIL)
+TEST(INVALIDCMD, CHECKLBA_FAIL)
 {
 	CommandParser parser;
 	vector<string> wrcmd = { "write","200","0x12345678" };
@@ -136,7 +136,7 @@ TEST(INVALIDCMD, CHECKWRITELBA_FAIL)
 	returnval = parser.checkValidLBA(rdcmd);
 	EXPECT_EQ(false, returnval);
 }
-TEST(INVALIDCMD, CHECKWRITELBA_PASS)
+TEST(INVALIDCMD, CHECKLBA_PASS)
 {
 	CommandParser parser;
 	vector<string> wrcmd = { "write","93","0x12345678" };
@@ -144,4 +144,24 @@ TEST(INVALIDCMD, CHECKWRITELBA_PASS)
 	vector<string> rdcmd = { "read","93" };
 	returnval = parser.checkValidLBA(rdcmd);
 	EXPECT_EQ(true, returnval);
+}
+
+TEST(INVALIDCMD, CHECKVALUE_FAIL)
+{
+	CommandParser parser;
+	vector<vector<string>> invalidcmdlist = {
+		{ "write","93","0x1234" },
+		{ "write","93","0x12345678AAA" },
+		{ "write","93","qwertyuiop" },
+		{ "write","93","01234567x0" },
+	};
+	bool returnval = true;
+	for (vector<string> cmd : invalidcmdlist)
+	{
+		returnval = parser.checkValidLBA(cmd);
+		if (returnval == true)
+			break;
+	}
+	
+	EXPECT_EQ(false, returnval);
 }


### PR DESCRIPTION
아래 Case에 대해서 Invalid 처리 되도록 UT 작성하였으며, PASS 했습니다. 
	
	{ "write","93","0x1234" },
		{ "write","93","0x12345678AAA" },
		{ "write","93","qwertyuiop" },
		{ "write","93","01234567x0" },
		{ "write","93","0x1234abcd" },		
		{ "fullwrite","0x1234" },
		{ "fullwrite","0x12345678AAA" },
		{ "fullwrite","qwertyuiop" },
		{ "fullwrite","01234567x0" },
		{ "fullwrite","0x1234abcd" },	