### PR TITLE
[add] FullWriteFail TC

### DIFF
--- a/TestShell_Excutor/TS_function_test.cpp
+++ b/TestShell_Excutor/TS_function_test.cpp
@@ -114,3 +114,17 @@ TEST_F(SSDFixture, FullWriteNormal) {
 	EXPECT_EQ(true, shell.fullwrite(data));
 }
 
+TEST_F(SSDFixture, FullWriteFail) {
+	data = 0xABCDFFFF;
+	EXPECT_CALL(ssd, write(_, data))
+		.Times(5)
+		.WillOnce(Return(true))
+		.WillOnce(Return(true))
+		.WillOnce(Return(true))
+		.WillOnce(Return(true))
+		.WillOnce(Return(false))
+		.WillRepeatedly(Return(true));
+
+	EXPECT_EQ(false, shell.fullwrite(data));
+}
+


### PR DESCRIPTION
[add] FullWriteFail TC
fullwrite도중 fail나는 경우의 TC인데, 이미 function에 false처리가 들어가 있어서 자동 TC pass처리 되었습니다.