### PR TITLE
Feature ssd read execute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -426,3 +426,6 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+#txt file
+*.txt

--- a/SSD_Excutor/read.cpp
+++ b/SSD_Excutor/read.cpp
@@ -11,12 +11,11 @@ public:
 		const std::string NAND_FILE = "ssd_nand.txt";
 		const std::string OUTPUT_FILE = "ssd_output.txt";
 
-		// 1. 기존 output 파일 존재 시 삭제
 		if (file_exists(OUTPUT_FILE)) {
 			if (std::remove(OUTPUT_FILE.c_str()) == 0) {
 			}
 			else {
-				std::cout << "파일 삭제 실패\n";
+				std::cout << "fail to delete " << OUTPUT_FILE << std::endl;
 			}
 		}
 
@@ -25,7 +24,7 @@ public:
 		std::ifstream nand(NAND_FILE);
 
 		if (!nand.is_open()) {
-			std::cout << "파일 열기 실패: " << NAND_FILE << "\n";
+			std::cout << "fail to open : " << NAND_FILE << "\n";
 		}
 		else {
 			while (std::getline(nand, line)) {
@@ -34,11 +33,11 @@ public:
 				std::istringstream iss(line);
 
 				if (!(iss >> addr >> value)) {
-					continue; // 형식이 잘못된 줄 무시
+					continue;
 				}
 
 				if (addr == address) {
-					matchedValue = value; // 최신 값으로 덮어쓰기
+					matchedValue = value;
 				}
 			}
 			nand.close();
@@ -50,7 +49,7 @@ public:
 			out.close();
 		}
 		else {
-			std::cout << "결과 파일 생성 실패\n";
+			std::cout << "fail to create output file";
 		}
 
 		return;

--- a/SSD_Excutor/read.cpp
+++ b/SSD_Excutor/read.cpp
@@ -1,10 +1,63 @@
 #pragma once
 #include <iostream>
+#include <fstream>
+#include <string>
+#include <sstream>	
 
 
 class Read {
 public:
-	std::string execute(unsigned int address) {
-		return "";
+	void execute(unsigned int address) {
+		const std::string NAND_FILE = "ssd_nand.txt";
+		const std::string OUTPUT_FILE = "ssd_output.txt";
+
+		// 1. 기존 output 파일 존재 시 삭제
+		if (file_exists(OUTPUT_FILE)) {
+			if (std::remove(OUTPUT_FILE.c_str()) == 0) {
+			}
+			else {
+				std::cout << "파일 삭제 실패\n";
+			}
+		}
+
+		std::string matchedValue = "0x00000000";
+		std::string line;
+		std::ifstream nand(NAND_FILE);
+
+		if (!nand.is_open()) {
+			std::cout << "파일 열기 실패: " << NAND_FILE << "\n";
+		}
+		else {
+			while (std::getline(nand, line)) {
+				unsigned int addr;
+				std::string value;
+				std::istringstream iss(line);
+
+				if (!(iss >> addr >> value)) {
+					continue; // 형식이 잘못된 줄 무시
+				}
+
+				if (addr == address) {
+					matchedValue = value; // 최신 값으로 덮어쓰기
+				}
+			}
+			nand.close();
+		}
+
+		std::ofstream out(OUTPUT_FILE);
+		if (out.is_open()) {
+			out << matchedValue;
+			out.close();
+		}
+		else {
+			std::cout << "결과 파일 생성 실패\n";
+		}
+
+		return;
+	}
+private:
+	bool file_exists(const std::string& filename) {
+		std::ifstream file(filename);
+		return file.good();
 	}
 };

--- a/SSD_Excutor/read_test.cpp
+++ b/SSD_Excutor/read_test.cpp
@@ -34,7 +34,7 @@ public:
             if (std::remove(SSD_FILE_NAME.c_str()) == 0) {
             }
             else {
-                std::cout << "파일 삭제 실패\n";
+                std::cout << "fail to delete " << SSD_FILE_NAME << std::endl;
             }
         }
         // clear OUTPUT_FILE_
@@ -42,7 +42,8 @@ public:
             if (std::remove(OUTPUT_FILE_NAME.c_str()) == 0) {
             }
             else {
-                std::cout << "파일 삭제 실패\n";
+                std::cout << "fail to delete " << OUTPUT_FILE_NAME << std::endl;
+
             }
         }
     }
@@ -74,7 +75,7 @@ TEST_F(ReadTestFixture, NeverWrittenReadReturnZero) {
     ssdHelper.resetSSD();
 
     unsigned int address = 0x0;
-    ssd.readCommand.execute(address);
+    readCommand.execute(address);
 
     unsigned int readValue = std::stoul(ssdHelper.getReadResultFromFile(), nullptr, 16);
 

--- a/SSD_Excutor/read_test.cpp
+++ b/SSD_Excutor/read_test.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include "read.cpp"
 #include "write.cpp"
+#include <sstream>
 
 using namespace testing;
 
@@ -29,7 +30,26 @@ public:
 
     void resetSSD() {
         // clear SSD_FILE_
+        if (file_exists(SSD_FILE_NAME)) {
+            if (std::remove(SSD_FILE_NAME.c_str()) == 0) {
+            }
+            else {
+                std::cout << "파일 삭제 실패\n";
+            }
+        }
         // clear OUTPUT_FILE_
+        if (file_exists(OUTPUT_FILE_NAME)) {
+            if (std::remove(OUTPUT_FILE_NAME.c_str()) == 0) {
+            }
+            else {
+                std::cout << "파일 삭제 실패\n";
+            }
+        }
+    }
+private:
+    bool file_exists(const std::string& filename) {
+        std::ifstream file(filename);
+        return file.good();
     }
 };
 
@@ -50,14 +70,15 @@ TEST_F(ReadTestFixture, ReadCommandLeavesOutputfile) {
 }
 
 // read command should return 0x00000000 even if ssd has never been used 
-TEST_F(ReadTestFixture, NeverWrittenReadReturnZero) {
-
-    int address = 0x0;
-    readCommand.execute(address);
-
+TEST_F(ReadTestFixture, NeverWrittenReadReturnZero) {    
     ssdHelper.resetSSD();
 
-    EXPECT_THAT(readCommand.execute(address), "0x00000000");
+    unsigned int address = 0x0;
+    ssd.readCommand.execute(address);
+
+    unsigned int readValue = std::stoul(ssdHelper.getReadResultFromFile(), nullptr, 16);
+
+    EXPECT_THAT(readValue, (unsigned int)0x00000000);
 }
 
 // if lba 1 is written with specific value, lba 1 read should return exactly same value.


### PR DESCRIPTION
SSD Read execute 동작에 대한 초기 구현입니다.
2개의 UT에 대해서 통과하도록 하였습니다.
- ReadCommandLeavesOutputfile : read 수행하면 output 파일이 생성되어야 한다.
- NeverWrittenReadReturnZero : 한 번도 write하지 않은 ssd에 대해서도 read를 수행하면 output에 0x00000000이 찍혀야 한다.

추가로 .txt 를 gitignore에 추가하였습니다.