### PR TITLE
[add] command의 type에 따라 실제 실행하는 command 처리 함수로 분기

### DIFF
--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -158,13 +158,27 @@ int CommandParser::runSubCommands(vector<string> cmdParms, int type)
 
 bool CommandParser::runCommandWrite(const string lba, const string value)
 {
-	std::cout << "[Write] Done\n";
-	return true;
+	int iLba = stoi(lba);
+	unsigned int iValue = strtoul(value.c_str(), nullptr, 16);
+	bool result = this->shell.write(iLba, iValue);
+	if (1) // FIXME
+		std::cout << "[Write] Done\n";
+	return result;
 }
 
 int CommandParser::runCommandRead(const string lba)
 {
-	return 0;
+	int iLba = stoi(lba);
+	unsigned int iValue = this->shell.read(iLba);
+	printReadResult(iLba, iValue);
+	return iValue;
+}
+
+void CommandParser::printReadResult(int lba, unsigned int value)
+{
+	std::stringstream ss;
+	ss << "0x" << uppercase << hex << setw(8) << setfill('0') << value;
+	std::cout << "[Read] LBA " << lba << " : " << ss.str() << std::endl;
 }
 
 void CommandParser::runCommandHelp(void)

--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -9,6 +9,7 @@ int CommandParser::runCommand(const string cmd) {
 		return CMD_NOT_SUPPORTED;
 
 	int type = getCommandType(cmdParms[0]);
+	runSubCommands(cmdParms, type);
 	return type;
 }
 
@@ -133,8 +134,50 @@ bool CommandParser::checkValidValue(vector<string> cmdSplits)
 	return false;
 }
 
+int CommandParser::runSubCommands(vector<string> cmdParms, int type)
+{
+	if (type == CMD_BASIC_WRITE) {
+		return runCommandWrite(cmdParms[1], cmdParms[2]);
+	}
+	else if (type == CMD_BASIC_READ) {
+		return runCommandRead(cmdParms[1]);
+	}
+	else if (type == CMD_BASIC_HELP) {
+		runCommandHelp();
+		return CMD_BASIC_HELP;
+	}
+	else if (type == CMD_BASIC_FULLWRITE) {
+		return runCommandFullWrite(cmdParms[1]);
+	}
+	else if (type == CMD_BASIC_FULLREAD) {
+		return runCommandFullRead();
+	}
+	else
+		return CMD_NOT_SUPPORTED;
+}
+
 bool CommandParser::runCommandWrite(const string lba, const string value)
 {
 	std::cout << "[Write] Done\n";
 	return true;
+}
+
+int CommandParser::runCommandRead(const string lba)
+{
+	return 0;
+}
+
+void CommandParser::runCommandHelp(void)
+{
+}
+
+bool CommandParser::runCommandFullWrite(const string value)
+{
+	std::cout << "[Write] Done\n";
+	return true;
+}
+
+int CommandParser::runCommandFullRead(void)
+{
+	return 0;
 }

--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -8,8 +8,8 @@ int CommandParser::runCommand(const string cmd) {
 	if (isInvalidCommand(cmdParms) == false)
 		return CMD_NOT_SUPPORTED;
 
-	// TODO : Run command and Print Log
-	return getCommandType(cmdParms[0]);
+	int type = getCommandType(cmdParms[0]);
+	return type;
 }
 
 vector<string> CommandParser::getCommandParams(const string& cmd)
@@ -133,5 +133,8 @@ bool CommandParser::checkValidValue(vector<string> cmdSplits)
 	return false;
 }
 
-
-
+bool CommandParser::runCommandWrite(const string lba, const string value)
+{
+	std::cout << "[Write] Done\n";
+	return true;
+}

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -1,10 +1,19 @@
 #pragma once
+#include "gmock/gmock.h"
+#include "TS_function.cpp"
+
 #include <vector>
 #include <iostream>
 #include <string>
 #include <unordered_map>
 using std::string;
 using std::vector;
+
+class MockSSD : public iTS_SSD {
+public:
+	MOCK_METHOD(unsigned int, read, (int lba), (override));
+	MOCK_METHOD(bool, write, (int lba, unsigned int data), (override));
+};
 
 enum CommandType {
 	CMD_NOT_SUPPORTED = -1,
@@ -68,4 +77,5 @@ private:
 	bool checkValidLBA(vector<string> str);
 	bool checkValidValue(vector<string> str);
 	
+	TS_function shell{ new testing::NiceMock<MockSSD>()};
 };

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -40,6 +40,7 @@ public:
 	int getCommandType(const string cmd);
 	bool isInvalidCommand(vector<string> str);
 	
+	bool runCommandWrite(const string lba, const string value);
 private:
 	const int CMDINDEX = 0;
 	const int LBAINDEX =1;

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -52,6 +52,7 @@ public:
 	int runSubCommands(vector<string> cmdParms, int type);
 	bool runCommandWrite(const string lba, const string value);
 	int runCommandRead(const string lba);
+	void printReadResult(int lba, unsigned int value);
 	void runCommandHelp(void);
 	bool runCommandFullWrite(const string value);
 	int runCommandFullRead(void);

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -40,7 +40,12 @@ public:
 	int getCommandType(const string cmd);
 	bool isInvalidCommand(vector<string> str);
 	
+	int runSubCommands(vector<string> cmdParms, int type);
 	bool runCommandWrite(const string lba, const string value);
+	int runCommandRead(const string lba);
+	void runCommandHelp(void);
+	bool runCommandFullWrite(const string value);
+	int runCommandFullRead(void);
 private:
 	const int CMDINDEX = 0;
 	const int LBAINDEX =1;

--- a/TestShell_Excutor/CommandParser_test.cpp
+++ b/TestShell_Excutor/CommandParser_test.cpp
@@ -40,3 +40,15 @@ TEST(CPTest, RunCommandCallRed) {
 	const string cmdline = "read 0";
 	EXPECT_EQ(CMD_BASIC_READ, cp.runCommand(cmdline));
 }
+TEST(CPTest, RunCommandWritePass) {
+	CommandParser cp;
+
+	std::stringstream buffer;
+	std::streambuf* old = std::cout.rdbuf(buffer.rdbuf());
+	int actual = cp.runCommandWrite("3", "0xAAAABBBB");
+
+	std::cout.rdbuf(old);
+	string output = buffer.str();
+	EXPECT_EQ(true, actual);
+	EXPECT_EQ(output, "[Write] Done\n");
+}

--- a/TestShell_Excutor/CommandParser_test.cpp
+++ b/TestShell_Excutor/CommandParser_test.cpp
@@ -40,15 +40,31 @@ TEST(CPTest, RunCommandCallRed) {
 	const string cmdline = "read 0";
 	EXPECT_EQ(CMD_BASIC_READ, cp.runCommand(cmdline));
 }
-TEST(CPTest, RunCommandWritePass) {
+TEST(CPTest, RunCommandWritePassDefault) {
 	CommandParser cp;
+	const string cmdline = "write 3 0xAAAABBBB";
 
 	std::stringstream buffer;
 	std::streambuf* old = std::cout.rdbuf(buffer.rdbuf());
-	int actual = cp.runCommandWrite("3", "0xAAAABBBB");
+	int expected = CMD_BASIC_WRITE;
+	int actual = cp.runCommand(cmdline);
 
 	std::cout.rdbuf(old);
 	string output = buffer.str();
-	EXPECT_EQ(true, actual);
+	EXPECT_EQ(expected, actual);
 	EXPECT_EQ(output, "[Write] Done\n");
+}
+TEST(CPTest, RunCommandReadPassDefault) {
+	CommandParser cp;
+	const string cmdline = "read 3";
+
+	std::stringstream buffer;
+	std::streambuf* old = std::cout.rdbuf(buffer.rdbuf());
+	int expected = CMD_BASIC_READ;
+	int actual = cp.runCommand(cmdline);
+
+	std::cout.rdbuf(old);
+	string output = buffer.str();
+	EXPECT_EQ(expected, actual);
+	EXPECT_EQ(output, "[Read] LBA 3 : 0x00000000\n");
 }

--- a/TestShell_Excutor/TS_function.cpp
+++ b/TestShell_Excutor/TS_function.cpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <iostream>
 #include <vector>
 using std::vector;


### PR DESCRIPTION
What:
Parsing 끝난 각 command의 type에 따라 실제 실행하는 command 처리 함수로 분기처리 해주는 로직 구현(red, green)입니다.
현재는 iTS_SDD의 read/write함수를 호출하기 위해서 Mocking 기법이 class내에 사용되고 있습니다.