### PR TITLE
add function calling for  SSD Excutor.exe

### DIFF
--- a/TestShell_Excutor/TS_function.cpp
+++ b/TestShell_Excutor/TS_function.cpp
@@ -1,6 +1,10 @@
 #include <iostream>
 #include <vector>
+#include <string>
+
+
 using std::vector;
+using std::string;
 
 #define interface struct
 
@@ -8,6 +12,19 @@ interface iTS_SSD {
 public:
 	virtual unsigned int read(int lba)=0;
 	virtual bool write(int lba , unsigned int data) = 0;
+};
+
+class SSDExecutor : public iTS_SSD {
+public:
+	unsigned int read(int lba) override {
+		return 0;
+	}
+	bool write(int lba, unsigned int data) override {
+
+		return 0;
+	}
+
+private:
 };
 
 class TS_function {

--- a/TestShell_Excutor/TS_function.cpp
+++ b/TestShell_Excutor/TS_function.cpp
@@ -17,7 +17,7 @@ public:
 class SSDExecutor : public iTS_SSD {
 public:
 	unsigned int read(int lba) override {
-		cmd = "\".\\SSD_Excutor.exe\" read " + std::to_string(lba);
+		cmd = SSDEXCUTE + " read " + std::to_string(lba);
 		int result = std::system(cmd.c_str());
 		if (result == 0) {
 			throw std::exception("Error System Call read");
@@ -26,7 +26,7 @@ public:
 		return 0;
 	}
 	bool write(int lba, unsigned int data) override {
-		cmd = "\".\\SSD_Excutor.exe\" write " + std::to_string(lba) + " " + (toHex(lba));
+		cmd = SSDEXCUTE + " write " + std::to_string(lba) + " " + (toHex(lba));
 		int result = std::system(cmd.c_str());
 		if (result == 0) {
 			return false;
@@ -43,6 +43,7 @@ private:
 		return ss.str();
 	}
 	string cmd = "";
+	string SSDEXCUTE = "\".\\SSD_Excutor.exe" ;
 };
 
 class TS_function {

--- a/TestShell_Excutor/TS_function.cpp
+++ b/TestShell_Excutor/TS_function.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
-
+#include <sstream>
 
 using std::vector;
 using std::string;
@@ -17,14 +17,32 @@ public:
 class SSDExecutor : public iTS_SSD {
 public:
 	unsigned int read(int lba) override {
+		cmd = "\".\\SSD_Excutor.exe\" read " + std::to_string(lba);
+		int result = std::system(cmd.c_str());
+		if (result == 0) {
+			throw std::exception("Error System Call read");
+		}
+
 		return 0;
 	}
 	bool write(int lba, unsigned int data) override {
+		cmd = "\".\\SSD_Excutor.exe\" write " + std::to_string(lba) + " " + (toHex(lba));
+		int result = std::system(cmd.c_str());
+		if (result == 0) {
+			return false;
+		}
+		return true;
 
-		return 0;
 	}
 
 private:
+
+	std::string toHex(unsigned int value) {
+		std::stringstream ss;
+		ss << "0x" << std::hex << std::uppercase << value;
+		return ss.str();
+	}
+	string cmd = "";
 };
 
 class TS_function {

--- a/TestShell_Excutor/TS_function_test.cpp
+++ b/TestShell_Excutor/TS_function_test.cpp
@@ -149,3 +149,19 @@ TEST_F(SSDFixture, ReadCompareDifferentDataFail) {
 
 	EXPECT_EQ(false, shell.readCompare(lba, writtenData));
 }
+
+TEST_F(SSDFixture, SSDExWrite_Normal) {
+	SSDExecutor ssde;
+	TS_function shell(&ssde);
+	bool expected = true;
+
+	EXPECT_EQ(expected, shell.write(lba,data));
+}
+
+TEST_F(SSDFixture, SSDExRead_Normal) {
+	SSDExecutor ssde;
+	TS_function shell(&ssde);
+	bool expected = 0;
+
+	EXPECT_EQ(expected, shell.read(lba));
+}

--- a/TestShell_Excutor/TS_function_test.cpp
+++ b/TestShell_Excutor/TS_function_test.cpp
@@ -162,6 +162,5 @@ TEST_F(SSDFixture, SSDExRead_Normal) {
 	SSDExecutor ssde;
 	TS_function shell(&ssde);
 	bool expected = 0;
-
 	EXPECT_EQ(expected, shell.read(lba));
 }

--- a/TestShell_Excutor/TS_function_test.cpp
+++ b/TestShell_Excutor/TS_function_test.cpp
@@ -122,8 +122,7 @@ TEST_F(SSDFixture, FullWriteFail) {
 		.WillOnce(Return(true))
 		.WillOnce(Return(true))
 		.WillOnce(Return(true))
-		.WillOnce(Return(false))
-		.WillRepeatedly(Return(true));
+		.WillRepeatedly(Return(false));
 
 	EXPECT_EQ(false, shell.fullwrite(data));
 }

--- a/TestShell_Excutor/TS_function_test.cpp
+++ b/TestShell_Excutor/TS_function_test.cpp
@@ -5,6 +5,7 @@
 using namespace testing;
 using std::vector;
 
+#define REAL_DEBUG 0
 class MockSSD : public iTS_SSD {
 public:
 	MOCK_METHOD(unsigned int, read, (int lba), (override));
@@ -127,7 +128,6 @@ TEST_F(SSDFixture, FullWriteFail) {
 	EXPECT_EQ(false, shell.fullwrite(data));
 }
 
-
 TEST_F(SSDFixture, ReadCompareCallSSDRead) {
 	unsigned int writtenData = 0x12345678;
 	unsigned int readData = writtenData;
@@ -149,6 +149,7 @@ TEST_F(SSDFixture, ReadCompareDifferentDataFail) {
 	EXPECT_EQ(false, shell.readCompare(lba, writtenData));
 }
 
+#if REAL_DEBUG
 TEST_F(SSDFixture, SSDExWrite_Normal) {
 	SSDExecutor ssde;
 	TS_function shell(&ssde);
@@ -163,3 +164,4 @@ TEST_F(SSDFixture, SSDExRead_Normal) {
 	bool expected = 0;
 	EXPECT_EQ(expected, shell.read(lba));
 }
+#endif


### PR DESCRIPTION
실제 SSD_Excutor.exe를 호출하는 TC와 코드입니다.
다른 테스트를 위해 임시로 TC disable 해서 올립니다.
[refactor] disable TC for other test
[refactor] remove warning in TC
[refactor] make common string
[add] add real write & read to systemcall for SSDEWrite/Read TC
[add] SSDExcute Write/Read TC
