### PR TITLE
refactoing ssd write sync function

### DIFF
--- a/SSD_Excutor/write.cpp
+++ b/SSD_Excutor/write.cpp
@@ -45,17 +45,13 @@ private:
 				std::string line = "";
 				getline(file, line);
 
-				std::string lbaStr;
-				std::string valueStr;
-				unsigned int lba;
-				unsigned int value;
-
 				std::istringstream iss(line);
-
-				iss >> lbaStr >> valueStr;
-				lba = stoi(lbaStr);
+				unsigned int lba;
+				std::string valueStr;
+				iss >> lba >> valueStr;
 
 				char* endptr;
+				unsigned int value;
 				value = strtoul(valueStr.c_str(), &endptr, 16);
 
 				map[lba] = value;


### PR DESCRIPTION
write의 sync 메서드의 불필요한 변수와 동작을 삭제하였습니다.