### PR TITLE
[fix] remove build warnings regarding to 'flag'

### DIFF
--- a/TestShell_Excutor/TS_function.cpp
+++ b/TestShell_Excutor/TS_function.cpp
@@ -112,7 +112,6 @@ public:
 		int LBA_MIN = 0;
 		int curWriteLBA = LBA_MIN;
 		int curReadLBA = LBA_MIN;
-		bool flag;
 		queue <WrittenData> datas;
 		WrittenData data;
 		


### PR DESCRIPTION
This patch removes build warnings regarding to  'flag' : derefernences