### PR TITLE
[clean] remove unused file(test.cpp)

### DIFF
--- a/TestShell_Excutor/TestShell_Excutor.vcxproj
+++ b/TestShell_Excutor/TestShell_Excutor.vcxproj
@@ -145,7 +145,6 @@
     <ClCompile Include="ShellTestScenarios.cpp" />
     <ClCompile Include="ShellWrite.cpp" />
     <ClCompile Include="TS_function.cpp" />
-    <ClCompile Include="test.cpp" />
     <ClCompile Include="TS_function_test.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/TestShell_Excutor/TestShell_Excutor.vcxproj.filters
+++ b/TestShell_Excutor/TestShell_Excutor.vcxproj.filters
@@ -7,9 +7,6 @@
     <ClCompile Include="TS_function_test.cpp">
       <Filter>테스트파일</Filter>
     </ClCompile>
-    <ClCompile Include="test.cpp">
-      <Filter>테스트파일</Filter>
-    </ClCompile>
     <ClCompile Include="CommandParser.cpp">
       <Filter>소스코드</Filter>
     </ClCompile>

--- a/TestShell_Excutor/test.cpp
+++ b/TestShell_Excutor/test.cpp
@@ -1,6 +1,0 @@
-#include "gmock/gmock.h"
-using namespace testing;
-
-TEST(BasicTC, Sample) {
-    EXPECT_EQ(1, 1);
-}


### PR DESCRIPTION
TestShell_Excutor/test.cpp is deprecated.

# Pull Request Template
## Title (Mandatory)
-[clean] remove unused file(test.cpp)

## Which solution? (Mandatory)
- [ ] SSD
- [ ] Logger
- [ ] TestScenario
- [x] TestShell

## Changes : What(feature/bugfix) -> Why(optional)
- TestShell_Excutor/test.cpp는 사용성이 없어 삭제 합니다.