### PR TITLE
[add] 1차 flush command enable

### DIFF
--- a/SSD_Excutor/command_buffer_manager.cpp
+++ b/SSD_Excutor/command_buffer_manager.cpp
@@ -1,6 +1,111 @@
 #include "command_buffer_manager.h"
+#include "erase.h"
+#include "write.h"
+#include "read.h"
+#include "command_factory.h"
+#include <iostream>
+#include <sstream>
 
-std::vector<std::string> CommandBufferManger::getCommandBufferList()
+namespace fs = std::filesystem;
+
+CommandBufferManager& CommandBufferManager::getInstance()
+{
+	static CommandBufferManager commandBufferManager;
+	return commandBufferManager;
+}
+
+std::vector<CommandBufferInfo> CommandBufferManager::getCommandBufferList()
 {
 	return commandBufferList;
+}
+
+void CommandBufferManager::syncCommandBuffer()
+{
+	if (fs::exists(folderPath) == false)
+	{
+
+		fs::create_directory(folderPath);
+
+		for (int i = 1; i <= 5; ++i) {
+			fs::path filePath = folderPath / (std::to_string(i) + "_empty");
+			std::ofstream outFile(filePath);
+			outFile.close();
+		}
+	}
+
+	for (const auto& entry : fs::directory_iterator("./buffer")) {
+		
+		commandBufferList.push_back(string2CommandBufferInfo(entry.path().filename().string()));
+		
+	}
+
+}
+
+std::string CommandBufferManager::commandBufferInfo2String(CommandBufferInfo commandBufferInfo)
+{
+	return "";
+}
+
+CommandBufferInfo CommandBufferManager::string2CommandBufferInfo(std::string str)
+{
+	std::stringstream ss(str);
+	std::string item;
+	std::vector<std::string> result;
+	CommandFactory cmdFactory;
+
+	while (std::getline(ss, item, '_')) {
+		result.push_back(item);
+	}
+
+	if (result[1] == "empty")
+	{
+		return CommandBufferInfo{ static_cast<unsigned int>(SSDCommand::SSDCommand_INVALID), 0xFFFFFFFF, 0xFFFFFFFF, nullptr };
+	}
+
+	std::vector<char*> argv;
+	for (auto& data : result) {
+		argv.push_back(const_cast<char*>(data.c_str()));
+	}
+
+	CommandInfo commandInfo = commandParser.parse(argv.size(), argv.data());
+	CommandBufferInfo commandBufferInfo = {commandInfo.command, commandInfo.lba, commandInfo.value, cmdFactory.CreateCommand(commandInfo.command)};
+
+	return commandBufferInfo;
+}
+
+void CommandBufferManager::optimizeCommandBuffer()
+{
+
+}
+
+void CommandBufferManager::updateCommandBuffer()
+{
+	
+}
+
+void CommandBufferManager::clearCommandBuffer()
+{
+	if (fs::exists(folderPath)) {
+		fs::remove_all(folderPath);
+	}
+
+	commandBufferList.clear();
+}
+
+void CommandBufferManager::run()
+{
+	syncCommandBuffer();
+}
+
+void CommandBufferManager::flush()
+{
+	for (int i = 0; i < commandBufferList.size(); i++)
+	{
+		if (commandBufferList[i].cmd != static_cast<unsigned int>(SSDCommand::SSDCommand_INVALID))
+		{
+			commandBufferList[i].commandStructure->execute(commandBufferList[i].param1, commandBufferList[i].param2);
+		}
+	}
+
+	clearCommandBuffer();
 }

--- a/SSD_Excutor/command_buffer_manager.h
+++ b/SSD_Excutor/command_buffer_manager.h
@@ -1,11 +1,38 @@
 #pragma once
 #include <vector>
 #include <string>
+#include "command_parser.h"
+#include "command_interface.h"
+#include <filesystem>
 
-class CommandBufferManger
+namespace fs = std::filesystem;
+
+struct CommandBufferInfo
+{
+	unsigned int cmd;
+	unsigned int param1;
+	unsigned int param2;
+	std::shared_ptr<ICommand> commandStructure;
+};
+
+class CommandBufferManager
 {
 public:
-	std::vector<std::string> getCommandBufferList();
+	std::vector<CommandBufferInfo> commandBufferList;
 
-	std::vector<std::string> commandBufferList;
+	static CommandBufferManager& getInstance();
+	std::vector<CommandBufferInfo> getCommandBufferList();
+	void flush();
+	void run();
+	void syncCommandBuffer();
+	CommandBufferInfo string2CommandBufferInfo(std::string str);
+	std::string commandBufferInfo2String(CommandBufferInfo commnadBufferInfo);
+	void optimizeCommandBuffer();
+	void updateCommandBuffer();
+	void clearCommandBuffer();
+
+private:
+	CommandBufferManager() = default;
+	CommandParser commandParser;
+	fs::path folderPath = fs::current_path() / "buffer";
 };

--- a/SSD_Excutor/command_buffer_manager_test.cpp
+++ b/SSD_Excutor/command_buffer_manager_test.cpp
@@ -1,4 +1,5 @@
 #include "gmock/gmock.h"
+#include "command_buffer_manager.h"
 
 TEST(CommandBufferMangerTS, TC1)
 {

--- a/SSD_Excutor/command_factory.cpp
+++ b/SSD_Excutor/command_factory.cpp
@@ -6,6 +6,10 @@ std::shared_ptr<ICommand> CommandFactory::CreateCommand(int commandNumber)
 		return std::make_shared<Write>();
 	else if (commandNumber == static_cast<int>(SSDCommand::SSDCommand_READ))
 		return std::make_shared<Read>();
+	else if (commandNumber == static_cast<int>(SSDCommand::SSDCommand_ERASE))
+		return std::make_shared<Erase>();
+	else if (commandNumber == static_cast<int>(SSDCommand::SSDCommand_FLUSH))
+		return std::make_shared<Flush>();
 
 	return nullptr;
 }

--- a/SSD_Excutor/command_factory.h
+++ b/SSD_Excutor/command_factory.h
@@ -5,6 +5,7 @@
 #include "read.h"
 #include "write.h"
 #include "erase.h"
+#include "flush.h"
 
 class CommandFactory {
 public:

--- a/SSD_Excutor/command_parser.cpp
+++ b/SSD_Excutor/command_parser.cpp
@@ -63,6 +63,11 @@ CommandInfo CommandParser::MakeCommandInfo(std::vector<std::string> cmdSplits)
 	return ret;
 }
 
+CommandFormat CommandParser::getCommandFormat(unsigned int commandNum)
+{
+	return commandlist[commandNum];
+}
+
 unsigned int CommandParser::getLBA(const CommandFormat& cmddata, const std::vector<std::string>& cmdSplits)
 {
 	if (cmddata.isUseLBA)

--- a/SSD_Excutor/command_parser.h
+++ b/SSD_Excutor/command_parser.h
@@ -38,6 +38,7 @@ public:
 	}*/
 	bool isValidCommand(std::vector<std::string> str);
 	CommandInfo MakeCommandInfo(std::vector<std::string> str);
+	CommandFormat getCommandFormat(unsigned int commandNum);
 
 
 private:

--- a/SSD_Excutor/flush.cpp
+++ b/SSD_Excutor/flush.cpp
@@ -2,10 +2,11 @@
 #include <filesystem>
 #include <string>
 #include "flush.h"
+#include "command_buffer_manager.h"
 
 void Flush::execute()
 {
-
+	CommandBufferManager::getInstance().flush();
 }
 
 

--- a/SSD_Excutor/flush_test.cpp
+++ b/SSD_Excutor/flush_test.cpp
@@ -1,7 +1,160 @@
 #include "gmock/gmock.h"
+#include "flush.h"
+#include "command_buffer_manager.h"
+#include <fstream>
 
+namespace fs = std::filesystem;
 
-TEST(flushTS, TC1)
+class FlushTS : public testing::Test {
+protected:
+	void SetUp() override
+	{
+		CommandBufferManager::getInstance().clearCommandBuffer();
+
+		fs::create_directory(folderPath);
+
+		file.open(nand);
+
+		if (file.is_open() == false)
+		{
+			FAIL();
+		}
+
+	}
+
+	void TearDown() override
+	{
+		file.close();
+	}
+
+public:
+	void makeCommandBuffer(unsigned int index, CommandInfo cmdInfo)
+	{
+		std::string line = "";
+		std::string value = "";
+
+		if (cmdInfo.command == static_cast<unsigned int>(SSDCommand::SSDCommand_WRITE))
+		{
+			std::ostringstream ss;
+			ss << "0x" << std::uppercase << std::setfill('0') << std::setw(8) << std::hex << cmdInfo.value;
+			value = ss.str();
+			line = std::to_string(index) + "_" + commandParser.getCommandFormat(cmdInfo.command).cmd + "_" + std::to_string(cmdInfo.lba) + "_" + value;
+		}
+		else if (cmdInfo.command == static_cast<unsigned int>(SSDCommand::SSDCommand_ERASE))
+		{
+			value = std::to_string(cmdInfo.value);
+			line = std::to_string(index) + "_" + commandParser.getCommandFormat(cmdInfo.command).cmd + "_" + std::to_string(cmdInfo.lba) + "_" + value;
+		}
+		else
+		{
+			line = std::to_string(index) + "_empty";
+		}
+
+		fs::path filePath = folderPath / (line);
+		std::ofstream outFile(filePath);
+		outFile.close();
+
+	}
+
+	std::string directAccessNand(unsigned int lba)
+	{
+		std::string line = "";
+		file.seekg(0);
+		for (int i = 0; i <= lba; i++)
+		{
+			getline(file, line);
+		}
+		return line;
+	}
+
+	void checkData(unsigned int expectedLba, unsigned int expectedValue, std::string actual)
+	{
+		std::string expected = "";
+		std::ostringstream ss;
+		ss << "0x" << std::uppercase << std::setfill('0') << std::setw(8) << std::hex << expectedValue;
+		expected = std::to_string(expectedLba) + " " + ss.str();
+		EXPECT_EQ(expected, actual);
+	}
+
+	CommandParser commandParser;
+	fs::path folderPath = fs::current_path() / "buffer";
+	std::string nand = "ssd_nand.txt";
+	std::ifstream file;
+
+};
+
+TEST_F(FlushTS, TC1)
 {
-	EXPECT_EQ(1, 1);
+	Flush flush;
+
+	makeCommandBuffer(1, CommandInfo{ 0, 1, 1 });
+	makeCommandBuffer(2, CommandInfo{ 0, 2, 2 });
+	makeCommandBuffer(3, CommandInfo{ 0, 3, 3 });
+	makeCommandBuffer(4, CommandInfo{ 0, 4, 4 });
+	makeCommandBuffer(5, CommandInfo{ 0, 5, 5 });
+
+	CommandBufferManager::getInstance().syncCommandBuffer();
+
+	flush.execute();
+
+	std::string actual;
+	actual = directAccessNand(1);
+	checkData(1, 1, actual);
+	actual = directAccessNand(2);
+	checkData(2, 2, actual);
+	actual = directAccessNand(3);
+	checkData(3, 3, actual);
+	actual = directAccessNand(4);
+	checkData(4, 4, actual);
+	actual = directAccessNand(5);
+	checkData(5, 5, actual);
+	
+}
+
+TEST_F(FlushTS, TC2)
+{
+	Flush flush;
+
+	makeCommandBuffer(1, CommandInfo{ 0, 1, 0xFFFF });
+	makeCommandBuffer(2, CommandInfo{ 5, 2, 0xFFFF });
+	makeCommandBuffer(3, CommandInfo{ 0, 3, 0x12345678 });
+	makeCommandBuffer(4, CommandInfo{ 5, 4, 4 });
+	makeCommandBuffer(5, CommandInfo{ 0, 5, 0xFFFFFFFF});
+
+	CommandBufferManager::getInstance().syncCommandBuffer();
+
+	flush.execute();
+
+	std::string actual;
+	actual = directAccessNand(1);
+	checkData(1, 0xFFFF, actual);
+	actual = directAccessNand(3);
+	checkData(3, 0x12345678, actual);
+	actual = directAccessNand(5);
+	checkData(5, 0xFFFFFFFF, actual);
+
+}
+
+TEST_F(FlushTS, TC3)
+{
+	Flush flush;
+
+	makeCommandBuffer(1, CommandInfo{ 0, 1, 0xFFFF });
+	makeCommandBuffer(2, CommandInfo{ 5, 2, 0xFFFF });
+	makeCommandBuffer(3, CommandInfo{ 0, 3, 0x12345678 });
+	makeCommandBuffer(4, CommandInfo{ 0, 4, 4 });
+	makeCommandBuffer(5, CommandInfo{ 2, 0, 10 });
+
+	CommandBufferManager::getInstance().syncCommandBuffer();
+
+	flush.execute();
+
+	std::string actual;
+	actual = directAccessNand(1);
+	checkData(1, 0, actual);
+	actual = directAccessNand(3);
+	checkData(3, 0, actual);
+	actual = directAccessNand(5);
+	checkData(5, 0, actual);
+
 }

--- a/SSD_Excutor/ssd.cpp
+++ b/SSD_Excutor/ssd.cpp
@@ -1,4 +1,5 @@
 #include "ssd.h"
+#include "command_buffer_manager.h"
 
 
 SSD::SSD(CommandParser* commandParser) :
@@ -15,6 +16,8 @@ void SSD::run(int argc, char* argv[])
 	FileUtil::deletePrevOutputFile();
 
 	CommandInfo commandInfo = commandParser->parse(argc, argv);
+
+	CommandBufferManager::getInstance().run();
 
 	if (commandInfo.command == static_cast<unsigned int>(SSDCommand::SSDCommand_WRITE))
 	{


### PR DESCRIPTION
# Pull Request Template
## Title (Mandatory)
- [add] 1차 flush command enable

## Which solution? (Mandatory)
- [x] SSD
- [ ] Logger
- [ ] TestScenario
- [ ] TestShell

## Changes : What(feature/bugfix) -> Why(optional)
- CommandBufferManager 생성
- CommandBufferManager를 SingleTon Pattern 사용 (SSD class와 Flush에서 사용하기 위해) CommandBufferManager를 통해 flush 하도록 하여 CommandBuffer에 대한 책임을 단일화

## To Reviewer(optional)
- 리뷰할때 미리 알아야 할 내용이 있다면 기입해주세요.