### PR TITLE
[add]TS4 command to parser & add UT for CreateCommandData

### DIFF
--- a/TestShell_Excutor/CommandData.h
+++ b/TestShell_Excutor/CommandData.h
@@ -20,6 +20,7 @@ enum CommandType {
 	CMD_TS_FullWriteAndReadCompare,
 	CMD_TS_PartialLBAWrite,
 	CMD_TS_WriteReadAging,
+	CMD_TS_EraseWriteAging,
 	CMD_MAX,
 	CMD_NOT_SUPPORTED,
 };

--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -38,10 +38,13 @@ CommandInfo CommandParser::createCommandData(const string cmd)
 		{
 			ret.command = getCommandType(cmdParms[0]);
 			ret.lba = getLBA(cmddata, cmdParms);
-			if(cmddata.isUseValue)
+			if (cmddata.isUseValue)
 				ret.value = getHexValue(cmddata, cmdParms);
-			else if(cmddata.isUseEndLBA)
+			else if (cmddata.isUseEndLBA)
 				ret.value = getEndLBA(cmddata, cmdParms);
+			else
+				ret.value = 0xFFFFFFFF;
+
 			ret.size = getSize(cmddata, cmdParms);
 		}
 	}

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -40,9 +40,11 @@ public:
 		{"1_FullWriteAndReadCompare",0,false,false,false,false," : No Param //Write and Read Compare @ AllRange"},
 		{"1_",0,false,false,false,false,"		: No Param//Write and Read Compare @ AllRange"},
 		{"2_PartialLBAWrite",0,false,false,false,false," : No Param //(Write 0x12345678 @LBA_0~4 & ReadCompare) * 30 times"},
-		{"2_",0,false,false,false,false,"		: No Param//(Write 0x12345678 @LBA_0~4 & ReadCompare) * 30 times"},
+		{"2_",0,false,false,false,false,"		: No Param//(Write 0x12345678++ @LBA_0~4 & ReadCompare) * 30 times"},
 		{"3_WriteReadAging",0,false,false,false,false," : No Param //(Write RandomValue @LBA_9 and @LBA_99) * 200 times"},
 		{"3_",0,false,false,false,false,"		: No Param//(Write RandomValue @LBA_9 and @LBA_99) * 200 times"},
+		{"4_EraseAndWriteAging",0,false,false,false,false," : No Param //(Write/OverWrite/Erase)* 30 times"},
+		{"4_",0,false,false,false,false,"		: No Param////(Write/OverWrite/Erase)* 30 times"},
 		{"exit",0,false,false,false,false,"		: No Param//Terminate Shell" },
 		{"help",0,false,false,false,false,"		: No Param//Print Command Usage"},
 	};
@@ -90,6 +92,8 @@ private:
 		{"2_", CMD_TS_PartialLBAWrite },
 		{"3_WriteReadAging", CMD_TS_WriteReadAging },
 		{"3_", CMD_TS_WriteReadAging },
+		{"4_WriteReadAging", CMD_TS_EraseWriteAging },
+		{"4_", CMD_TS_EraseWriteAging },
 	};
 	vector<string> getCommandParams(const std::string& cmd);
 	

--- a/TestShell_Excutor/CommandParser_test.cpp
+++ b/TestShell_Excutor/CommandParser_test.cpp
@@ -12,23 +12,123 @@ private:
 	CommandParser cp;
 };
 
-TEST_F(CPFixture, BasicInvalidCommand) {
-	EXPECT_EQ(CMD_NOT_SUPPORTED, checkCommandType("invalid"));
+class CommandParserTS :public Test {
+public:
+	CommandParser commandParser;
+
+	
+	void checkExpected(const CommandInfo& expected, const CommandInfo& actual)
+	{
+		EXPECT_EQ(expected.command, actual.command);
+		EXPECT_EQ(expected.lba, actual.lba);
+		EXPECT_EQ(expected.value, actual.value);
+		EXPECT_EQ(expected.size, actual.size);
+	}
+
+};
+TEST_F(CommandParserTS, Invalid)
+{
+	const string command = "invlaid 3 0xAAAABBBB";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF ,-1};
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
 }
-TEST_F(CPFixture, BasicValidCommand) {
-	EXPECT_EQ(CMD_BASIC_WRITE, checkCommandType("write"));
-	EXPECT_EQ(CMD_BASIC_READ, checkCommandType("read"));
-	EXPECT_EQ(CMD_BASIC_EXIT, checkCommandType("exit"));
-	EXPECT_EQ(CMD_BASIC_HELP, checkCommandType("help"));
-	EXPECT_EQ(CMD_BASIC_FULLWRITE, checkCommandType("fullwrite"));
-	EXPECT_EQ(CMD_BASIC_FULLREAD, checkCommandType("fullread"));
-	EXPECT_EQ(CMD_TS_FullWriteAndReadCompare, checkCommandType("1_FullWriteAndReadCompare"));
-	EXPECT_EQ(CMD_TS_FullWriteAndReadCompare, checkCommandType("1_"));
-	EXPECT_EQ(CMD_TS_PartialLBAWrite, checkCommandType("2_PartialLBAWrite"));
-	EXPECT_EQ(CMD_TS_PartialLBAWrite, checkCommandType("2_"));
-	EXPECT_EQ(CMD_TS_WriteReadAging, checkCommandType("3_WriteReadAging"));
-	EXPECT_EQ(CMD_TS_WriteReadAging, checkCommandType("3_"));
+TEST_F(CommandParserTS, WrteTC1)
+{
+	const string command = "write 3 0xAAAABBBB";
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_WRITE, 3 , 0xAAAABBBB,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
 }
+TEST_F(CommandParserTS, WrteTC2)
+{
+	const string command = "write 3";
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF ,-1};
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, WrteTC3)
+{
+	const string command = "write 3 0";
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, WrteTC4)
+{
+	const string command = "write 3 0xABCDEFGH";
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, Read)
+{
+	const string command = "read 3 ";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_READ, 3 , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, Read1)
+{
+	const string command = "read 3 0xAAAABBBB";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, Erase)
+{
+	const string command = "erase 50 -10";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_ERASE, 50 , 0xFFFFFFFF,-10 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+
+TEST_F(CommandParserTS, EraseRange)
+{
+	const string command = "erase_range 90 100";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_ERASE_RANGE, 90 , 100,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+
+TEST_F(CommandParserTS, TS1)
+{
+	const string command = "1_";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_TS_FullWriteAndReadCompare, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, TS4)
+{
+	const string command = "4_";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_TS_EraseWriteAging, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+//TEST_F(CPFixture, BasicInvalidCommand) {
+//	EXPECT_EQ(CMD_NOT_SUPPORTED, checkCommandType("invalid"));
+//}
+//TEST_F(CPFixture, BasicValidCommand) {
+//	EXPECT_EQ(CMD_BASIC_WRITE, checkCommandType("write"));
+//	EXPECT_EQ(CMD_BASIC_READ, checkCommandType("read"));
+//	EXPECT_EQ(CMD_BASIC_EXIT, checkCommandType("exit"));
+//	EXPECT_EQ(CMD_BASIC_HELP, checkCommandType("help"));
+//	EXPECT_EQ(CMD_BASIC_FULLWRITE, checkCommandType("fullwrite"));
+//	EXPECT_EQ(CMD_BASIC_FULLREAD, checkCommandType("fullread"));
+//	EXPECT_EQ(CMD_TS_FullWriteAndReadCompare, checkCommandType("1_FullWriteAndReadCompare"));
+//	EXPECT_EQ(CMD_TS_FullWriteAndReadCompare, checkCommandType("1_"));
+//	EXPECT_EQ(CMD_TS_PartialLBAWrite, checkCommandType("2_PartialLBAWrite"));
+//	EXPECT_EQ(CMD_TS_PartialLBAWrite, checkCommandType("2_"));
+//	EXPECT_EQ(CMD_TS_WriteReadAging, checkCommandType("3_WriteReadAging"));
+//	EXPECT_EQ(CMD_TS_WriteReadAging, checkCommandType("3_"));
+//}
 
 TEST(CPTest, RunCommandCallExit) {
 	CommandParser cp;


### PR DESCRIPTION
# Pull Request Template
## Title (Mandatory)
- [add]TS4 command to parser & add UT for CreateCommandData

## Which solution? (Mandatory)
- [ ] SSD
- [ ] Logger
- [ ] TestScenario
- [x] TestShell

## Changes : What(feature/bugfix) -> Why(optional)
- shell command parser에 TS4 추가
- CreateCommandData 를 위한 UT 추가 및 Pass확인
-
## To Reviewer(optional)
- parser에서 commandData를 저장하여 넘겨주기로 변경하여 기존에 CommandType을 확인하는 UT 주석처리