### PR TITLE
[Fix]erase_range LBA Condition & CommandFormat Struct field type

### DIFF
--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -72,8 +72,7 @@ bool CommandParser::isValidCommand(vector<string> cmdSplits)
 		return false;
 	if (checkValidSize(cmdSplits) == false)
 		return false;
-	/*if (checkValiEndLBA(cmdSplits) == false)
-		return false;*/
+
 	return true;
 }
 

--- a/TestShell_Excutor/CommandParser.cpp
+++ b/TestShell_Excutor/CommandParser.cpp
@@ -37,11 +37,12 @@ CommandInfo CommandParser::createCommandData(const string cmd)
 		if (cmddata.cmd == cmdParms[CMDINDEX])
 		{
 			ret.command = getCommandType(cmdParms[0]);
-			ret.lba = getLBA(cmddata, cmdParms);
-			if (cmddata.isUseValue)
+			ret.lba = getLBA(cmddata.lbaIndex, cmdParms);
+			//value is used for HexValue and EndLBA
+			if (cmddata.valueIndex > 0)
 				ret.value = getHexValue(cmddata, cmdParms);
-			else if (cmddata.isUseEndLBA)
-				ret.value = getEndLBA(cmddata, cmdParms);
+			else if (cmddata.endLbaIndex >0 )
+				ret.value = getLBA(cmddata.endLbaIndex, cmdParms);
 			else
 				ret.value = 0xFFFFFFFF;
 
@@ -71,8 +72,8 @@ bool CommandParser::isValidCommand(vector<string> cmdSplits)
 		return false;
 	if (checkValidSize(cmdSplits) == false)
 		return false;
-	if (checkValiEndLBA(cmdSplits) == false)
-		return false;
+	/*if (checkValiEndLBA(cmdSplits) == false)
+		return false;*/
 	return true;
 }
 
@@ -109,17 +110,27 @@ bool CommandParser::checkValidLBA(vector<string> cmdSplits)
 	{
 		if (cmddata.cmd == cmdSplits[CMDINDEX])
 		{
-			if (cmddata.isUseLBA)
+			if (cmddata.lbaIndex>0)
 			{
 
-				string lbastr = cmdSplits[LBAINDEX];
+				string lbastr = cmdSplits[cmddata.lbaIndex];
+				if (lbastr.size() <= 0 || lbastr.size() > LBAMAXLENGTH)
+					return false;
+
+				if (isNumber(lbastr) == false)
+					return false;
+			}
+
+			if (cmddata.endLbaIndex>0)
+			{
+				string lbastr = cmdSplits[cmddata.endLbaIndex];
 				if (lbastr.size() <= 0 || lbastr.size() > LBAMAXLENGTH)
 					return false;
 
 				return isNumber(lbastr);
 			}
-			else
-				return true;
+
+			return true;
 		}
 	}
 	return false;
@@ -127,19 +138,20 @@ bool CommandParser::checkValidLBA(vector<string> cmdSplits)
 
 bool CommandParser::checkValiEndLBA(vector<string> cmdSplits)
 {
-	for (CommandFormat cmddata : commandlist)
+	/*for (CommandFormat cmddata : commandlist)
 	{
 		if (cmddata.cmd == cmdSplits[CMDINDEX])
 		{
-			if (cmddata.isUseEndLBA)
+			if (cmddata.endLbaIndex>0)
 			{
-				string lbastr = cmdSplits[VALUEINDEX];
+				string lbastr = cmdSplits[cmddata.endLbaIndex];
 				return isNumber(lbastr);
 			}
 			else
 				return true;
 		}
 	}
+	return false;*/
 	return false;
 }
 
@@ -154,10 +166,9 @@ bool CommandParser::checkValidValue(vector<string> cmdSplits)
 	{
 		if (cmddata.cmd == cmdSplits[CMDINDEX])
 		{
-			if (cmddata.isUseValue)
+			if (cmddata.valueIndex>0)
 			{
-				int valueIndex = cmddata.paramnum; //value is lastindex
-				string valueStr = cmdSplits[valueIndex];
+				string valueStr = cmdSplits[cmddata.valueIndex];
 				if (valueStr.size() != VALUELENGTH)
 					return false;
 				return isHex(valueStr);
@@ -283,9 +294,9 @@ bool CommandParser::checkValidSize(vector<string> cmdSplits)
 	{
 		if (cmddata.cmd == cmdSplits[CMDINDEX])
 		{
-			if (cmddata.isUseSize)
+			if (cmddata.sizeIndex>0)
 			{
-				string sizestr = cmdSplits[SIZEINDEX];
+				string sizestr = cmdSplits[cmddata.sizeIndex];
 				if (sizestr[0] == '-')
 				{
 					return isNumber(sizestr.substr(1, sizestr.length()));
@@ -331,27 +342,20 @@ bool CommandParser::isHex(const std::string& str)
 	return true;
 }
 
-unsigned int CommandParser::getLBA(const CommandFormat& cmddata, const std::vector<std::string>& cmdSplits)
+unsigned int CommandParser::getLBA(int lbaIndex, const std::vector<std::string>& cmdSplits)
 {
-	if (cmddata.isUseLBA)
+	if (lbaIndex>0 )
 	{
-		return getDecimal(cmdSplits[LBAINDEX]);
+		return getDecimal(cmdSplits[lbaIndex]);
 	}
 	return 0xFFFFFFFF;
 }
-unsigned int CommandParser::getEndLBA(const CommandFormat& cmddata, const std::vector<std::string>& cmdSplits)
-{
-	if (cmddata.isUseEndLBA)
-	{
-		return getDecimal(cmdSplits[VALUEINDEX]);
-	}
-	return 0xFFFFFFFF;
-}
+
 unsigned int CommandParser::getSize(const CommandFormat& cmddata, const std::vector<std::string>& cmdSplits)
 {
-	if (cmddata.isUseSize)
+	if (cmddata.sizeIndex>0)
 	{
-		return getSignedDecimal(cmdSplits[SIZEINDEX]);
+		return getSignedDecimal(cmdSplits[cmddata.sizeIndex]);
 	}
 	return -1;
 }
@@ -389,11 +393,11 @@ int  CommandParser::getSignedDecimal(const string& str)
 unsigned int CommandParser::getHexValue(const CommandFormat& cmddata, const std::vector<std::string>& cmdSplits)
 {
 
-	if (cmddata.isUseValue)
+	if (cmddata.valueIndex>0 )
 	{
 		try {
 
-			return std::stoul(cmdSplits[VALUEINDEX], nullptr, 16);
+			return std::stoul(cmdSplits[cmddata.valueIndex], nullptr, 16);
 		}
 		catch (const std::invalid_argument& e) {
 			std::cerr << "Invalid argument: " << e.what() << std::endl;

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -21,32 +21,33 @@ struct CommandFormat
 {
 	string cmd;
 	int paramnum;
-	bool isUseLBA;
-	bool isUseValue;
-	bool isUseSize;
-	bool isUseEndLBA;
+	int lbaIndex;
+	int valueIndex;
+	int sizeIndex;
+	int endLbaIndex;
 	string usage;
 };
 
 class CommandParser {
 public:
 	vector<CommandFormat> commandlist = {
-		{"write",2,true,true,false,false," <LBA> <VALUE> : LBA = 0~99 , VALUE = 0x00000000~0xFFFFFFFF(10 Digit)// Write Value @LBA"},
-		{"read",1,true,false,false,false," <LBA>         : LBA = 0~99 // Read @LBA"},
-		{"erase",2,true,false,true,false," <LBA> <SIZE> : LBA = 0~99 , SIZE = (+/-Decimal)// Erase Value @LBA ~@LBA+SIZE"},
-		{"erase_range",2,true,false,false,true," <START_LBA> <END_LBA>: LBA = 0~99 // Erase @ STARTLBA~ENDLBA"},
-		{"fullwrite",1,false,true,false,false," <VALUE>  : VALUE = 0x00000000~0xFFFFFFFF(10 Digit) // Write Value @ALL LBA"},
-		{"fullread",0,false,false,false,false,"          : No Param //Read Full Range"},
-		{"1_FullWriteAndReadCompare",0,false,false,false,false," : No Param //Write and Read Compare @ AllRange"},
-		{"1_",0,false,false,false,false,"		: No Param//Write and Read Compare @ AllRange"},
-		{"2_PartialLBAWrite",0,false,false,false,false," : No Param //(Write 0x12345678 @LBA_0~4 & ReadCompare) * 30 times"},
-		{"2_",0,false,false,false,false,"		: No Param//(Write 0x12345678++ @LBA_0~4 & ReadCompare) * 30 times"},
-		{"3_WriteReadAging",0,false,false,false,false," : No Param //(Write RandomValue @LBA_9 and @LBA_99) * 200 times"},
-		{"3_",0,false,false,false,false,"		: No Param//(Write RandomValue @LBA_9 and @LBA_99) * 200 times"},
-		{"4_EraseAndWriteAging",0,false,false,false,false," : No Param //(Write/OverWrite/Erase)* 30 times"},
-		{"4_",0,false,false,false,false,"		: No Param////(Write/OverWrite/Erase)* 30 times"},
-		{"exit",0,false,false,false,false,"		: No Param//Terminate Shell" },
-		{"help",0,false,false,false,false,"		: No Param//Print Command Usage"},
+
+		{"write",2,1,2,0,0," <LBA> <VALUE> : LBA = 0~99 , VALUE = 0x00000000~0xFFFFFFFF(10 Digit)// Write Value @LBA"},
+		{"read",1,1,0,0,0," <LBA>         : LBA = 0~99 // Read @LBA"},
+		{"erase",2,1,0,2,0," <LBA> <SIZE> : LBA = 0~99 , SIZE = (+/-Decimal)// Erase Value @LBA ~@LBA+SIZE"},
+		{"erase_range",2,1,0,0,2," <START_LBA> <END_LBA>: LBA = 0~99 // Erase @ STARTLBA~ENDLBA"},
+		{"fullwrite",1,0,1,0,0," <VALUE>  : VALUE = 0x00000000~0xFFFFFFFF(10 Digit) // Write Value @ALL LBA"},
+		{"fullread",0,0,0,0,0,"          : No Param //Read Full Range"},
+		{"1_FullWriteAndReadCompare",0,0,0,0,0," : No Param //Write and Read Compare @ AllRange"},
+		{"1_",0,0,0,0,0,"		: No Param//Write and Read Compare @ AllRange"},
+		{"2_PartialLBAWrite",0,0,0,0,0," : No Param //(Write 0x12345678 @LBA_0~4 & ReadCompare) * 30 times"},
+		{"2_",0,0,0,0,0,"		: No Param//(Write 0x12345678++ @LBA_0~4 & ReadCompare) * 30 times"},
+		{"3_WriteReadAging",0,0,0,0,0," : No Param //(Write RandomValue @LBA_9 and @LBA_99) * 200 times"},
+		{"3_",0,0,0,0,0,"		: No Param//(Write RandomValue @LBA_9 and @LBA_99) * 200 times"},
+		{"4_EraseAndWriteAging",0,0,0,0,0," : No Param //(Write/OverWrite/Erase)* 30 times"},
+		{"4_",0,0,0,0,0,"		: No Param////(Write/OverWrite/Erase)* 30 times"},
+		{"exit",0,0,0,0,0,"		: No Param//Terminate Shell" },
+		{"help",0,0,0,0,0,"		: No Param//Print Command Usage"},
 	};
 	
 
@@ -65,10 +66,7 @@ public:
 	int runCommandTestScenario(int type);
 private:
 	const int CMDINDEX = 0;
-	const int LBAINDEX =1;
-	const int ENDLBAINDEX = 2;
-	const int VALUEINDEX = 2;
-	const int SIZEINDEX = 2;
+	
 	const int LBAMAXLENGTH = 2;
 	const int HEXSTART = 2;
 	const int VALUELENGTH = 10;
@@ -105,8 +103,8 @@ private:
 	bool checkValiEndLBA(vector<string> cmdSplits);
 
 	CommandInfo MakeInvalidCmdData();
-	unsigned int getLBA(const CommandFormat& cmddata, const std::vector<std::string>& strlist);
-	unsigned int getEndLBA(const CommandFormat& cmddata, const std::vector<std::string>& strlist);
+	unsigned int getLBA(int lbaIndex, const std::vector<std::string>& strlist);
+	//unsigned int getEndLBA(const CommandFormat& cmddata, const std::vector<std::string>& strlist);
 
 	unsigned int getSize(const CommandFormat& cmddata, const std::vector<std::string>& strlist);
 	int getSignedDecimal(const string& str);

--- a/TestShell_Excutor/CommandParser.h
+++ b/TestShell_Excutor/CommandParser.h
@@ -104,8 +104,6 @@ private:
 
 	CommandInfo MakeInvalidCmdData();
 	unsigned int getLBA(int lbaIndex, const std::vector<std::string>& strlist);
-	//unsigned int getEndLBA(const CommandFormat& cmddata, const std::vector<std::string>& strlist);
-
 	unsigned int getSize(const CommandFormat& cmddata, const std::vector<std::string>& strlist);
 	int getSignedDecimal(const string& str);
 	unsigned int getDecimal(const string& str);

--- a/TestShell_Excutor/CommandParser_test.cpp
+++ b/TestShell_Excutor/CommandParser_test.cpp
@@ -78,6 +78,14 @@ TEST_F(CommandParserTS, Read1)
 	CommandInfo actual = commandParser.createCommandData(command);
 	checkExpected(expected, actual);
 }
+TEST_F(CommandParserTS, Read2)
+{
+	const string command = "read 200";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
 TEST_F(CommandParserTS, Erase)
 {
 	const string command = "erase 50 -10";
@@ -86,16 +94,78 @@ TEST_F(CommandParserTS, Erase)
 	CommandInfo actual = commandParser.createCommandData(command);
 	checkExpected(expected, actual);
 }
-
-TEST_F(CommandParserTS, EraseRange)
+TEST_F(CommandParserTS, Erase1)
 {
-	const string command = "erase_range 90 100";
+	const string command = "erase 50 0x10";
 
-	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_ERASE_RANGE, 90 , 100,-1 };
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
 	CommandInfo actual = commandParser.createCommandData(command);
 	checkExpected(expected, actual);
 }
+TEST_F(CommandParserTS, Erase2)
+{
+	const string command = "erase 50 1000";
 
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_ERASE, 50 , 0xFFFFFFFF,1000 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, EraseRange)
+{
+	const string command = "erase_range 0 99";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_ERASE_RANGE, 0 , 99,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, EraseRange1)
+{
+	const string command = "erase_range 90 1000";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, FullWrite)
+{
+	const string command = "fullwrite 0x12345678";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_FULLWRITE, 0xFFFFFFFF , 0x12345678,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, FullWrite1)
+{
+	const string command = "fullwrite 0x12345678DDD";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, FullWrite2)
+{
+	const string command = "fullwrite 10";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, Fullread)
+{
+	const string command = "fullread 10";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_NOT_SUPPORTED, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
+TEST_F(CommandParserTS, Fullread1)
+{
+	const string command = "fullread";
+
+	CommandInfo expected = { (unsigned int)CommandType::CMD_BASIC_FULLREAD, 0xFFFFFFFF , 0xFFFFFFFF,-1 };
+	CommandInfo actual = commandParser.createCommandData(command);
+	checkExpected(expected, actual);
+}
 TEST_F(CommandParserTS, TS1)
 {
 	const string command = "1_";

--- a/TestShell_Excutor/InvalidCmd_test.cpp
+++ b/TestShell_Excutor/InvalidCmd_test.cpp
@@ -228,6 +228,8 @@ TEST(INVALIDCMD, ERASERANGEFAIL)
 	vector<vector<string>> invalidcmdlist = {		
 		{ "erase_range","95","-5" },//FAIL	
 		{ "erase_range","-5","10" },//FAIL	
+		{ "erase_range","0","100" },//pass
+
 	};
 	int passIndex = 0;
 	for (vector<string> cmd : invalidcmdlist)
@@ -237,7 +239,7 @@ TEST(INVALIDCMD, ERASERANGEFAIL)
 		passIndex++;
 	}
 
-	EXPECT_EQ(2, passIndex);
+	EXPECT_EQ(3, passIndex);
 }
 
 TEST(INVALIDCMD, ERASERANGEPASS)
@@ -247,7 +249,6 @@ TEST(INVALIDCMD, ERASERANGEPASS)
 		{ "erase_range","95","5" },//PASS	
 		{ "erase_range","93","97" },//pass
 		{ "erase_range","0","97" },//pass
-		{ "erase_range","0","100" },//pass
 
 	};
 	int passIndex = 0;
@@ -258,5 +259,5 @@ TEST(INVALIDCMD, ERASERANGEPASS)
 		passIndex++;
 	}
 
-	EXPECT_EQ(4, passIndex);
+	EXPECT_EQ(3, passIndex);
 }


### PR DESCRIPTION
# Pull Request Template
## Title (Mandatory)
- [Fix]erase_range LBA Condition & CommandFormat Struct field type

## Which solution? (Mandatory)
- [ ] SSD
- [ ] Logger
- [ ] TestScenario
- [x] TestShell

## Changes : What(feature/bugfix) -> Why(optional)
- erase_range parameter precondition 조건 수정
- 아래처럼 Value를 사용하는 Index가 command마다 달라서 isUsed(param)의 자료형을 인덱스로 변경하여
  각 command format 설정할 때 Index 지정할 수 있도록 Refactor
- write [LBA] [VALUE]
- fullwrite [VALUE]
- why
- 강사님께 확인해보니, erase_range [START_LBA] [END_LBA]의 경우 기존 LBA조건 (0~99) 이 만족해야 한다고 합니다. 
- erase 명령어에서의 size만 - / + 숫자 형으로 range가 자유로운 조건
## To Reviewer(optional)
- 리뷰할때 미리 알아야 할 내용이 있다면 기입해주세요.