### PR TITLE
[refactor] detailedCommonInfo를 제거하고 CommandInfo로 통일하여 사용

### DIFF
--- a/SSD_Excutor/command_buffer_manager.h
+++ b/SSD_Excutor/command_buffer_manager.h
@@ -8,12 +8,6 @@
 
 namespace fs = std::filesystem;
 
-struct DetailedCommandInfo
-{
-	CommandInfo commandInfo;
-	std::shared_ptr<ICommand> commandStructure;
-};
-
 class CommandBufferManager
 {
 public:
@@ -21,7 +15,7 @@ public:
 
 	static CommandBufferManager& getInstance();
 	void initialize();
-	virtual std::vector<DetailedCommandInfo> getCommandBufferList();
+	virtual std::vector<CommandInfo> getCommandBufferList();
 	void flush();
 	bool inputCommandBuffer(CommandInfo commandInfo);
 	void syncCommandBuffer();
@@ -31,20 +25,20 @@ private:
 #ifndef _DEBUG
 	CommandBufferManager() = default;
 #endif
-	DetailedCommandInfo string2CommandBufferInfo(std::string str);
-	std::string commandBufferInfo2String(unsigned int bufferIndex, DetailedCommandInfo commnadBufferInfo);
+	CommandInfo string2CommandBufferInfo(std::string str);
+	std::string commandBufferInfo2String(unsigned int bufferIndex, CommandInfo commandInfo);
 
 	void updateCommandBuffer();
 
 	void optimizeCommandBuffer();
-	void updateMapForCommand(DetailedCommandInfo* detailedcommandInfo);
+	void updateMapForCommand(CommandInfo* commandInfo);
 
 	CommandParser commandParser;
 	fs::path folderPath = fs::current_path() / "buffer";
 	std::vector<bool> bufferEnbledCommand;
-	std::vector<DetailedCommandInfo> commandBufferList;
-	std::vector<DetailedCommandInfo> optimizedCommandBufferList;
+	std::vector<CommandInfo> commandBufferList;
+	std::vector<CommandInfo> optimizedCommandBufferList;
 	int checkOptimizePossible{ 0 };
 
-	std::array<DetailedCommandInfo*, 100> mapForOptimizeCommand;
+	std::array<CommandInfo*, 100> mapForOptimizeCommand;
 };

--- a/SSD_Excutor/proxyRead.cpp
+++ b/SSD_Excutor/proxyRead.cpp
@@ -17,12 +17,12 @@ void ProxyRead::execute(CommandInfo commandInfo) {
 }
 std::string ProxyRead::getHexValueFromBuffer(unsigned int address)
 {
-	std::vector<DetailedCommandInfo>commandBufferVector = cbm->getCommandBufferList();
+	std::vector<CommandInfo>commandBufferVector = cbm->getCommandBufferList();
 
 	int vectorSize = static_cast<int>(commandBufferVector.size());
 	for (int i = vectorSize - 1; i >= 0; --i) {
 		if (isBufferHitWriteCommand(commandBufferVector[i], address)) {
-			return toHexString(commandBufferVector[i].commandInfo.value);
+			return toHexString(commandBufferVector[i].value);
 		}
 		else if (isBufferHitEraseCommand(commandBufferVector[i], address)) {
 			return "0x00000000";
@@ -31,23 +31,23 @@ std::string ProxyRead::getHexValueFromBuffer(unsigned int address)
 	return "";
 }
 
-bool ProxyRead::isBufferHitWriteCommand(const DetailedCommandInfo& detailedCommandInfo, unsigned int address) {
-	if (detailedCommandInfo.commandInfo.command == static_cast<int>(SSDCommand::SSDCommand_WRITE)) {
-		if (detailedCommandInfo.commandInfo.lba == address) return true;
+bool ProxyRead::isBufferHitWriteCommand(const CommandInfo& commandInfo, unsigned int address) {
+	if (commandInfo.command == static_cast<int>(SSDCommand::SSDCommand_WRITE)) {
+		if (commandInfo.lba == address) return true;
 	}
 	return false;
 }
 
-bool ProxyRead::isBufferHitEraseCommand(const DetailedCommandInfo& detailedCommandInfo, unsigned int address) {
-	if (detailedCommandInfo.commandInfo.command == static_cast<int>(SSDCommand::SSDCommand_ERASE)) {
-		if (detailedCommandInfo.commandInfo.lba <= address && detailedCommandInfo.commandInfo.lba + detailedCommandInfo.commandInfo.value > address)
+bool ProxyRead::isBufferHitEraseCommand(const CommandInfo& commandInfo, unsigned int address) {
+	if (commandInfo.command == static_cast<int>(SSDCommand::SSDCommand_ERASE)) {
+		if (commandInfo.lba <= address && commandInfo.lba + commandInfo.value > address)
 			return true;
 	}
 	return false;
 }
 
 bool ProxyRead::bufferHit(unsigned int address) {
-	std::vector<DetailedCommandInfo>commandBufferVector = cbm->getCommandBufferList();
+	std::vector<CommandInfo>commandBufferVector = cbm->getCommandBufferList();
 
 	int vectorSize = static_cast<int>(commandBufferVector.size());
 	for (int i = vectorSize - 1; i >= 0; --i) {

--- a/SSD_Excutor/proxyRead.h
+++ b/SSD_Excutor/proxyRead.h
@@ -15,6 +15,6 @@ public:
     CommandBufferManager* cbm;
 
 private:
-	bool isBufferHitWriteCommand(const DetailedCommandInfo& detailedCommandInfo, unsigned int address);
-    bool isBufferHitEraseCommand(const DetailedCommandInfo& detailedCommandInfo, unsigned int address);
+	bool isBufferHitWriteCommand(const CommandInfo& commandInfo, unsigned int address);
+    bool isBufferHitEraseCommand(const CommandInfo& commandInfo, unsigned int address);
 };

--- a/SSD_Excutor/proxyRead_test.cpp
+++ b/SSD_Excutor/proxyRead_test.cpp
@@ -10,7 +10,7 @@ using namespace testing;
 #ifdef _DEBUG
 class MockCommandBufferManager : public CommandBufferManager {
 public:
-    MOCK_METHOD(std::vector<DetailedCommandInfo>, getCommandBufferList,(), (override));
+    MOCK_METHOD(std::vector<CommandInfo>, getCommandBufferList,(), (override));
 };
 
 class ProxyReadTestFixture : public Test {
@@ -26,12 +26,11 @@ public:
 TEST_F(ProxyReadTestFixture, HitBuffer)
 {
     //buffer에서 가져온 값이 hit 되어야 한다.
-    std::vector<DetailedCommandInfo> stubList;
+    std::vector<CommandInfo> stubList;
     unsigned int cmd = static_cast<unsigned int>(0);
     unsigned int targetAddress = static_cast<unsigned int>(0x3);
     unsigned int value = static_cast<unsigned int>(0x3);
-    std::shared_ptr<ICommand> stubCmd = std::make_shared<Write>();
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{cmd, targetAddress,value}, stubCmd });
+    stubList.push_back(CommandInfo{cmd, targetAddress,value});
 
     EXPECT_CALL(mock, getCommandBufferList)
         .WillOnce(Return(stubList));
@@ -41,13 +40,12 @@ TEST_F(ProxyReadTestFixture, HitBuffer)
 TEST_F(ProxyReadTestFixture, HitBufferWriteCommand)
 {
     //buffer에서 가져온 값이 hit 되어야 한다.
-    std::vector<DetailedCommandInfo> stubList;
-    std::shared_ptr<ICommand> stubCmd = std::make_shared<Write>();
+    std::vector<CommandInfo> stubList;
     unsigned int targetAddress = static_cast<unsigned int>(0x3);
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{0, 1, 1}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{0, 2, 2}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{0, targetAddress, 3}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{0, 4, 4}, stubCmd });
+    stubList.push_back(CommandInfo{0, 1, 1});
+    stubList.push_back(CommandInfo{0, 2, 2});
+    stubList.push_back(CommandInfo{0, targetAddress, 3});
+    stubList.push_back(CommandInfo{0, 4, 4});
 
     EXPECT_CALL(mock, getCommandBufferList)
         .WillRepeatedly(Return(stubList));
@@ -57,15 +55,14 @@ TEST_F(ProxyReadTestFixture, HitBufferWriteCommand)
 TEST_F(ProxyReadTestFixture, HitBufferEraseCommand)
 {
     //buffer에서 가져온 값이 hit 되어야 한다.
-    std::vector<DetailedCommandInfo> stubList;
-    std::shared_ptr<ICommand> stubCmd = std::make_shared<Write>();
+    std::vector<CommandInfo> stubList;
     unsigned int eraseStartAddress = static_cast<unsigned int>(0x11);
     unsigned int eraseRange = static_cast<unsigned int>(0x5);
     
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{0, 1, 1}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{0, 2, 2}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{2, eraseStartAddress, eraseRange}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{0, 4, 4}, stubCmd });
+    stubList.push_back(CommandInfo{0, 1, 1});
+    stubList.push_back(CommandInfo{0, 2, 2});
+    stubList.push_back(CommandInfo{2, eraseStartAddress, eraseRange});
+    stubList.push_back(CommandInfo{0, 4, 4});
 
     EXPECT_CALL(mock, getCommandBufferList)
         .WillRepeatedly(Return(stubList));
@@ -76,13 +73,12 @@ TEST_F(ProxyReadTestFixture, HitBufferEraseCommand)
 // Fail to hit buffer
 TEST_F(ProxyReadTestFixture, FailToHitBuffer)
 {
-    std::vector<DetailedCommandInfo> stubList;
+    std::vector<CommandInfo> stubList;
     unsigned int cmd = static_cast<unsigned int>(0);
     unsigned int nonTargAddress = 0x1;
     unsigned int targetAddress = static_cast<unsigned int>(0x3);
     unsigned int value = static_cast<unsigned int>(0x2);
-    std::shared_ptr<ICommand> stubCmd = std::make_shared<Write>();
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{cmd, nonTargAddress,value}, stubCmd });
+    stubList.push_back(CommandInfo{cmd, nonTargAddress,value});
     EXPECT_CALL(mock, getCommandBufferList)
         .WillRepeatedly(Return(stubList));
     EXPECT_EQ(proxyRead.bufferHit(targetAddress), false);
@@ -91,12 +87,11 @@ TEST_F(ProxyReadTestFixture, FailToHitBuffer)
 // Read From buffer
 TEST_F(ProxyReadTestFixture, ReadFromBufferWithWriteCommand)
 {
-    std::vector<DetailedCommandInfo> stubList;
+    std::vector<CommandInfo> stubList;
     unsigned int cmd = static_cast<unsigned int>(0);
     unsigned int param1 = static_cast<unsigned int>(0x31);
     unsigned int param2 = static_cast<unsigned int>(0x32);
-    std::shared_ptr<ICommand> stubCmd = std::make_shared<Erase>();
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{ cmd, param1,param2}, stubCmd });
+    stubList.push_back(CommandInfo{ cmd, param1,param2});
 
     EXPECT_CALL(mock, getCommandBufferList)
         .WillRepeatedly(Return(stubList));
@@ -107,12 +102,11 @@ TEST_F(ProxyReadTestFixture, ReadFromBufferWithWriteCommand)
 
 TEST_F(ProxyReadTestFixture, ReadFromBufferWithEraseCommand)
 {
-    std::vector<DetailedCommandInfo> stubList;
+    std::vector<CommandInfo> stubList;
     unsigned int cmd = 2;
     unsigned int targetAddress = 0x31;
     unsigned int targetRange = 0x10;
-    std::shared_ptr<ICommand> stubCmd = std::make_shared<Erase>();
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{ cmd, targetAddress,targetRange}, stubCmd });
+    stubList.push_back(CommandInfo{ cmd, targetAddress,targetRange});
 
     EXPECT_CALL(mock, getCommandBufferList)
         .WillRepeatedly(Return(stubList));
@@ -124,12 +118,11 @@ TEST_F(ProxyReadTestFixture, ReadFromBufferWithEraseCommand)
 
 TEST_F(ProxyReadTestFixture, ReadFromBufferWithComplexCommand)
 {
-    std::vector<DetailedCommandInfo> stubList;
-    std::shared_ptr<ICommand> stubCmd = std::make_shared<Write>();
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{ 0, 1, 1}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{ 0, 2, 2}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{ 0, 3, 3}, stubCmd });
-    stubList.push_back(DetailedCommandInfo{ CommandInfo{ 2, 2, 2}, stubCmd });
+    std::vector<CommandInfo> stubList;
+    stubList.push_back(CommandInfo{ 0, 1, 1});
+    stubList.push_back(CommandInfo{ 0, 2, 2});
+    stubList.push_back(CommandInfo{ 0, 3, 3});
+    stubList.push_back(CommandInfo{ 2, 2, 2});
 
     EXPECT_CALL(mock, getCommandBufferList)
         .WillRepeatedly(Return(stubList));


### PR DESCRIPTION
# Pull Request Template
## Title (Mandatory)
- [refactor] detailedCommonInfo를 제거하고 CommandInfo로 통일하여 사용

## Which solution? (Mandatory)
- [x] SSD
- [ ] Logger
- [ ] TestScenario
- [ ] TestShell

## Changes : What(feature/bugfix) -> Why(optional)
- detailedCommonInfo를 제거하고 CommandInfo로 통일하여 사용

## To Reviewer(optional)
- 리뷰할때 미리 알아야 할 내용이 있다면 기입해주세요.