### PR TITLE
[refactor] code clean for LBA_MAX/LBA_MIN

### DIFF
--- a/TestShell_Excutor/ShellCommand.h
+++ b/TestShell_Excutor/ShellCommand.h
@@ -3,6 +3,9 @@
 #include "CommandData.h"
 
 
+const int LBA_MAX = 99;
+const int LBA_MIN = 0;
+
 interface ShellCommandItem {
 public:
 	ShellCommandItem() {}

--- a/TestShell_Excutor/ShellErase.h
+++ b/TestShell_Excutor/ShellErase.h
@@ -8,6 +8,4 @@ public:
 	bool execute(CommandInfo cmdInfo) override;
 private:
 	iTS_SSD* ssd;
-	const int LBA_MAX = 99;
-	const int LBA_MIN = 0;
 };

--- a/TestShell_Excutor/ShellEraseRange.h
+++ b/TestShell_Excutor/ShellEraseRange.h
@@ -9,6 +9,4 @@ public:
 	bool execute(CommandInfo cmdInfo) override;
 private:
 	iTS_SSD* ssd;
-	const int LBA_MAX = 99;
-	const int LBA_MIN = 0;
 };

--- a/TestShell_Excutor/ShellFullRead.h
+++ b/TestShell_Excutor/ShellFullRead.h
@@ -9,7 +9,5 @@ public:
 private:
 	void printReadResult(int lba, unsigned int value);
 	iTS_SSD* ssd;
-	const int LBA_MAX = 99;
-	const int LBA_MIN = 0;
 };
 

--- a/TestShell_Excutor/ShellFullWrite.h
+++ b/TestShell_Excutor/ShellFullWrite.h
@@ -10,6 +10,4 @@ public:
 private:
 	iTS_SSD* ssd;
 	void printWriteDone();
-	const int LBA_MAX = 99;
-	const int LBA_MIN = 0;
 };

--- a/TestShell_Excutor/ShellRead.h
+++ b/TestShell_Excutor/ShellRead.h
@@ -11,6 +11,4 @@ private:
 	void printReadResult(int lba, unsigned int value);
 	iTS_SSD* ssd;
 	Logger* log;
-	const int LBA_MAX = 99;
-	const int LBA_MIN = 0;
 };

--- a/TestShell_Excutor/ShellTestScenarios.h
+++ b/TestShell_Excutor/ShellTestScenarios.h
@@ -37,8 +37,6 @@ private:
 
 	iTS_SSD* ssd;
 	const unsigned int DUMMY_WRITE_DATA = 0x12345678;
-	const int LBA_MAX = 99;
-	const int LBA_MIN = 0;
 	void initScenarioMap();
 	void printScenarioResult(bool isSuccess);
 	using ScenarioFunc = std::function<bool()>;


### PR DESCRIPTION
## Changes : What(feature/bugfix) -> Why(optional)
- 중복선언된 멤버변수를 대표 헤더로 옮기는 리팩토링 입니다.
- LBA_MAX/LBA_MIN unify to ShellCommand.h header to discard code redundancy

## Which solution (Mandatory)
- [ ] SSD
- [ ] Logger
- [x] TestShell / TestScenario