### PR TITLE
[fix] returns result of execute() if build mode is release

### DIFF
--- a/TestShell_Excutor/ShellRunner.cpp
+++ b/TestShell_Excutor/ShellRunner.cpp
@@ -41,7 +41,11 @@ int ShellRunner::runCommand(const string cmd) {
 	else {
 		result = runShellCommand(cmdInfo);
 	}
+#ifdef _DEBUG
 	return type;
+#else
+	return (int)result;
+#endif
 }
 bool ShellRunner::runShellCommand(CommandInfo cmdInfo) {
 	Logger::getInstance()->print(__FUNCTION__, "called");

--- a/TestShell_Excutor/ShellRunner.cpp
+++ b/TestShell_Excutor/ShellRunner.cpp
@@ -52,11 +52,7 @@ bool ShellRunner::runShellCommand(CommandInfo cmdInfo) {
 	if (it != commandMap.end()) {
 		result = it->second->execute(cmdInfo);
 	}	
-#ifdef _DEBUG
-	return type;
-#else
-	return (int)result;
-#endif
+	return result;
 }
 
 int ShellRunner::runScriptFile(const char* filename) {


### PR DESCRIPTION
## Changes : What(feature/bugfix) -> Why(optional)
-  This patch fixes return value from runShellCommand.
 When run to execute write in runner mode,
 the return value is type(CMD_BASIC_WRITE = 0),
 which causes the runner mode to stop(due to it returns false).

 And this is a way to compatible with UT::ShellRunner_test.

## Which solution (Mandatory)
- [ ] SSD
- [ ] Logger
- [x] TestShell / TestScenario

## To Reviewer(optional)
- ShellRunner_test UT를 유지하기 위해서 release와 debug동작을 분리했습니다.