### PR TITLE
[fix] fix ut error due to singleton pattern / minor refactor

### DIFF
--- a/TestShell_Excutor/ShellTestScenario_test.cpp
+++ b/TestShell_Excutor/ShellTestScenario_test.cpp
@@ -15,6 +15,13 @@ public:
 
 class TestScenarioFixture : public Test {
 public:
+	void SetUp() override {
+		TestScenario::ResetInstance();
+		shell = TestScenario::GetInstance(&ssd);
+	}
+	void TearDown() override {
+
+	}
 	void setUpFullWriteAndReadCompare(){
 		redirectBufferSetup();
 		cmdInfo.command = CommandType::CMD_TS_FullWriteAndReadCompare;
@@ -39,9 +46,8 @@ public:
 		string output = buffer.str();
 		EXPECT_EQ(output, expected);
 	}
-	MockSSD ssd;
-	TestScenario* shell = TestScenario::GetInstance(&ssd);
-	//TestScenario shell{ &ssd };
+	NiceMock<MockSSD> ssd;
+	TestScenario* shell;
 	CommandInfo cmdInfo;
 	int lba = 0;
 	unsigned int data = 0x12345678;

--- a/TestShell_Excutor/ShellTestScenarios.h
+++ b/TestShell_Excutor/ShellTestScenarios.h
@@ -17,6 +17,10 @@ public:
 		}
 		return instance;
 	}
+	static void ResetInstance() {
+		delete instance;
+		instance = nullptr;
+	}
 	bool execute(CommandInfo cmdInfo) override;
 	unsigned int getRandomUnsignedInt();
 	bool readCompare(int lba, unsigned int writtenData);


### PR DESCRIPTION
## Changes : What(feature/bugfix) -> Why(optional)
- singleton pattern 도입 이후 scenario unittest fail 에 대한 fix 입니다.
-  UT  Setup 에서 기존  Instance 를 reset 하도록 추가했습니다.
-  Setup/teardown 으로 중복되는 command 를 정리했습니다.

## Which solution (Mandatory)
- [ ] SSD
- [ ] Logger
- [x] TestShell / TestScenario

## To Reviewer(optional)
- 리뷰할때 미리 알아야 할 내용이 있다면 기입해주세요.